### PR TITLE
Added shellcode arguments functionality

### DIFF
--- a/OffensivePipeline/Modules/Donut.cs
+++ b/OffensivePipeline/Modules/Donut.cs
@@ -46,6 +46,10 @@ namespace OffensivePipeline.Modules
                     config.Bypass = 3; //Behavior for bypassing AMSI/WLDP : 1=None, 2=Abort on fail, 3=Continue on fail.(default)
                     config.InputFile = exe;
                     config.Payload = Path.Combine(_moduleOutput.OutputPath, $"{_tool.name}.bin");
+                    if (_tool.toolArguments != "") {
+                        LogHelpers.PrintOk($"\t - Arguments passed to shellcode : \"{_tool.toolArguments}\"");
+                        config.Args = _tool.toolArguments;
+                    }
                     int ret = Generator.Donut_Create(ref config);
                     message = "\t\t[+] No errors!";
                     LogHelpers.PrintOk(message);

--- a/OffensivePipeline/Program.cs
+++ b/OffensivePipeline/Program.cs
@@ -214,7 +214,7 @@ Examples:
  - List all tools:
     OffensivePipeline.exe list
  - Load seatbelt tool:
-    OffensivePipeline.exe t seatbelt [args]
+    OffensivePipeline.exe t seatbelt [-a/--args] [args]
  - Load all tools:
     OffensivePipeline.exe all
 ";
@@ -254,14 +254,13 @@ Examples:
                 command.Description = "Load the specified tool";
                 command.HelpOption("-?|-h|--help");
                 var toolArgument = command.Argument("[tool]", "Tool to build.");
-                var toolArguments = command.Argument("[args]", "Command-line arguments to pass to the tool in the Donut shellcode, will override the yaml value");
-                toolArguments.DefaultValue = "";
-
+                var toolArguments = command.Option("-a|--args", "Command-line arguments to pass to the Donut shellcode, will override the yaml value", CommandOptionType.SingleValue);
+                
                 command.OnExecute(() =>
                 {
                     if (toolArgument.Value != null)
                     {
-                        LaunchPipeline(toolArgument.Value, toolArguments.Value);
+                        LaunchPipeline(toolArgument.Value, toolArguments.Value());
                     }
                     Console.WriteLine();
                     return 0;

--- a/OffensivePipeline/Program.cs
+++ b/OffensivePipeline/Program.cs
@@ -52,12 +52,12 @@ namespace OffensivePipeline
             Directory.CreateDirectory(Conf.outputPath);
         }
 
-        public static void LaunchPipeline(string toolName=null)
+        public static void LaunchPipeline(string toolName=null, string toolArguments=null)
         {
             List<ToolConfig> lTools = new List<ToolConfig>();
             if (toolName != null)
             {
-                lTools = YmlHelpers.ReadYmls(toolName);
+                lTools = YmlHelpers.ReadYmls(toolName, toolArguments);
             }
             else
             {
@@ -214,7 +214,7 @@ Examples:
  - List all tools:
     OffensivePipeline.exe list
  - Load seatbelt tool:
-    OffensivePipeline.exe t seatbelt
+    OffensivePipeline.exe t seatbelt [args]
  - Load all tools:
     OffensivePipeline.exe all
 ";
@@ -254,11 +254,14 @@ Examples:
                 command.Description = "Load the specified tool";
                 command.HelpOption("-?|-h|--help");
                 var toolArgument = command.Argument("[tool]", "Tool to build.");
+                var toolArguments = command.Argument("[args]", "Command-line arguments to pass to the tool in the Donut shellcode, will override the yaml value");
+                toolArguments.DefaultValue = "";
+
                 command.OnExecute(() =>
                 {
                     if (toolArgument.Value != null)
                     {
-                        LaunchPipeline(toolArgument.Value);
+                        LaunchPipeline(toolArgument.Value, toolArguments.Value);
                     }
                     Console.WriteLine();
                     return 0;

--- a/OffensivePipeline/ToolConfig.cs
+++ b/OffensivePipeline/ToolConfig.cs
@@ -8,7 +8,7 @@ namespace OffensivePipeline
 {
     public class ToolConfig
     {
-        public ToolConfig(string name, string description, string gitLink, string solutionPath, string language, string plugins, string authUser, string authToken)
+        public ToolConfig(string name, string description, string gitLink, string solutionPath, string language, string plugins, string authUser, string authToken, string toolArguments)
         {
             this.name = name;
             this.description = description;
@@ -18,6 +18,7 @@ namespace OffensivePipeline
             this.plugins = plugins.Split(',').Select(s => s.Trim()).ToList<string>();
             this.authUser = authUser;
             this.authToken = authToken;
+            this.toolArguments = toolArguments;
         }
 
         public string name { get; set; }
@@ -28,5 +29,6 @@ namespace OffensivePipeline
         public List<string> plugins { get; set; }
         public string authUser { get; set; }
         public string authToken { get; set; }
+        public string toolArguments { get; set; }
     }
 }

--- a/OffensivePipeline/Tools/ADCSPwn.yml
+++ b/OffensivePipeline/Tools/ADCSPwn.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/ADCollector.yml
+++ b/OffensivePipeline/Tools/ADCollector.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/ADFSDump.yml
+++ b/OffensivePipeline/Tools/ADFSDump.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/ADSearch.yml
+++ b/OffensivePipeline/Tools/ADSearch.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/BetterSafetyKatz.yml
+++ b/OffensivePipeline/Tools/BetterSafetyKatz.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/Certify.yml
+++ b/OffensivePipeline/Tools/Certify.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/DeployPrinterNightmare.yml
+++ b/OffensivePipeline/Tools/DeployPrinterNightmare.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/EDD.yml
+++ b/OffensivePipeline/Tools/EDD.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/ForgeCert.yml
+++ b/OffensivePipeline/Tools/ForgeCert.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/Group3r.yml
+++ b/OffensivePipeline/Tools/Group3r.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/KrbRelay.yml
+++ b/OffensivePipeline/Tools/KrbRelay.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/KrbRelayUp.yml
+++ b/OffensivePipeline/Tools/KrbRelayUp.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/LockLess.yml
+++ b/OffensivePipeline/Tools/LockLess.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/PassTheCert.yml
+++ b/OffensivePipeline/Tools/PassTheCert.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/PurpleSharp.yml
+++ b/OffensivePipeline/Tools/PurpleSharp.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/Rubeus.yml
+++ b/OffensivePipeline/Tools/Rubeus.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/Tools/SafetyKatz.yml
+++ b/OffensivePipeline/Tools/SafetyKatz.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SauronEye.yml
+++ b/OffensivePipeline/Tools/SauronEye.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SearchOutlook.yml
+++ b/OffensivePipeline/Tools/SearchOutlook.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/Seatbelt.yml
+++ b/OffensivePipeline/Tools/Seatbelt.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken: 
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharPersist.yml
+++ b/OffensivePipeline/Tools/SharPersist.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/Sharp-SMBExec.yml
+++ b/OffensivePipeline/Tools/Sharp-SMBExec.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpAppLocker.yml
+++ b/OffensivePipeline/Tools/SharpAppLocker.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpBypassUAC.yml
+++ b/OffensivePipeline/Tools/SharpBypassUAC.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpCOM.yml
+++ b/OffensivePipeline/Tools/SharpCOM.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpChisel.yml
+++ b/OffensivePipeline/Tools/SharpChisel.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpChromium.yml
+++ b/OffensivePipeline/Tools/SharpChromium.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpCloud.yml
+++ b/OffensivePipeline/Tools/SharpCloud.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpCookieMonster.yml
+++ b/OffensivePipeline/Tools/SharpCookieMonster.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpCrashEventLog.yml
+++ b/OffensivePipeline/Tools/SharpCrashEventLog.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpDPAPI.yml
+++ b/OffensivePipeline/Tools/SharpDPAPI.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpDir.yml
+++ b/OffensivePipeline/Tools/SharpDir.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpDump.yml
+++ b/OffensivePipeline/Tools/SharpDump.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpEDRChecker.yml
+++ b/OffensivePipeline/Tools/SharpEDRChecker.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpExec.yml
+++ b/OffensivePipeline/Tools/SharpExec.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpGPOAbuse.yml
+++ b/OffensivePipeline/Tools/SharpGPOAbuse.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpHandler.yml
+++ b/OffensivePipeline/Tools/SharpHandler.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpHose.yml
+++ b/OffensivePipeline/Tools/SharpHose.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpHound3.yml
+++ b/OffensivePipeline/Tools/SharpHound3.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken:  
+    authToken:      
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpKatz.yml
+++ b/OffensivePipeline/Tools/SharpKatz.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpLAPS.yml
+++ b/OffensivePipeline/Tools/SharpLAPS.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpMapExec.yml
+++ b/OffensivePipeline/Tools/SharpMapExec.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpMiniDump.yml
+++ b/OffensivePipeline/Tools/SharpMiniDump.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpMove.yml
+++ b/OffensivePipeline/Tools/SharpMove.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpNamedPipePTH.yml
+++ b/OffensivePipeline/Tools/SharpNamedPipePTH.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpNoPSExec.yml
+++ b/OffensivePipeline/Tools/SharpNoPSExec.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpPrinter.yml
+++ b/OffensivePipeline/Tools/SharpPrinter.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpRDP.yml
+++ b/OffensivePipeline/Tools/SharpRDP.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:     
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpReg.yml
+++ b/OffensivePipeline/Tools/SharpReg.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpSCCM.yml
+++ b/OffensivePipeline/Tools/SharpSCCM.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpSQLPwn.yml
+++ b/OffensivePipeline/Tools/SharpSQLPwn.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpScribbles.yml
+++ b/OffensivePipeline/Tools/SharpScribbles.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpSearch.yml
+++ b/OffensivePipeline/Tools/SharpSearch.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpSecDump.yml
+++ b/OffensivePipeline/Tools/SharpSecDump.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpShares.yml
+++ b/OffensivePipeline/Tools/SharpShares.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpSniper.yml
+++ b/OffensivePipeline/Tools/SharpSniper.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpSphere.yml
+++ b/OffensivePipeline/Tools/SharpSphere.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpSpray.yml
+++ b/OffensivePipeline/Tools/SharpSpray.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpStay.yml
+++ b/OffensivePipeline/Tools/SharpStay.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpSvc.yml
+++ b/OffensivePipeline/Tools/SharpSvc.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpTask.yml
+++ b/OffensivePipeline/Tools/SharpTask.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpUp.yml
+++ b/OffensivePipeline/Tools/SharpUp.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpView.yml
+++ b/OffensivePipeline/Tools/SharpView.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpWMI.yml
+++ b/OffensivePipeline/Tools/SharpWMI.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpWebServer.yml
+++ b/OffensivePipeline/Tools/SharpWebServer.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpWifiGrabber.yml
+++ b/OffensivePipeline/Tools/SharpWifiGrabber.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SharpZeroLogon.yml
+++ b/OffensivePipeline/Tools/SharpZeroLogon.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/Shhmon.yml
+++ b/OffensivePipeline/Tools/Shhmon.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/Snaffler.yml
+++ b/OffensivePipeline/Tools/Snaffler.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SqlClient.yml
+++ b/OffensivePipeline/Tools/SqlClient.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/StandIn.yml
+++ b/OffensivePipeline/Tools/StandIn.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/SweetPotato.yml
+++ b/OffensivePipeline/Tools/SweetPotato.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/ThreatCheck.yml
+++ b/OffensivePipeline/Tools/ThreatCheck.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken:  
+    authToken:      
+    toolArguments: 

--- a/OffensivePipeline/Tools/TokenStomp.yml
+++ b/OffensivePipeline/Tools/TokenStomp.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/TruffleSnout.yml
+++ b/OffensivePipeline/Tools/TruffleSnout.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/WMIReg.yml
+++ b/OffensivePipeline/Tools/WMIReg.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/Watson.yml
+++ b/OffensivePipeline/Tools/Watson.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/Tools/Whisker.yml
+++ b/OffensivePipeline/Tools/Whisker.yml
@@ -7,3 +7,4 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken:  
+    toolArguments: 

--- a/OffensivePipeline/Tools/winPEAS.yml
+++ b/OffensivePipeline/Tools/winPEAS.yml
@@ -6,4 +6,5 @@ tool:
     language: c#
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
-    authToken: 
+    authToken:
+    toolArguments: 

--- a/OffensivePipeline/YmlHelpers.cs
+++ b/OffensivePipeline/YmlHelpers.cs
@@ -46,7 +46,8 @@ namespace OffensivePipeline
                                     item.Children[new YamlScalarNode("language")].ToString(),
                                     item.Children[new YamlScalarNode("plugins")].ToString(),
                                     item.Children[new YamlScalarNode("authUser")].ToString(),
-                                    item.Children[new YamlScalarNode("authToken")].ToString()
+                                    item.Children[new YamlScalarNode("authToken")].ToString(),
+                                    item.Children[new YamlScalarNode("toolArguments")].ToString()
                                     ));
                             }
                             catch (Exception e)
@@ -61,7 +62,7 @@ namespace OffensivePipeline
             return lTools;
         }
 
-        public static List<ToolConfig> ReadYmls(string ymlName)
+        public static List<ToolConfig> ReadYmls(string ymlName, string overrideArguments)
         {
             List<ToolConfig> lTools = new List<ToolConfig>();
 
@@ -95,7 +96,8 @@ namespace OffensivePipeline
                                 item.Children[new YamlScalarNode("language")].ToString(),
                                 item.Children[new YamlScalarNode("plugins")].ToString(),
                                 item.Children[new YamlScalarNode("authUser")].ToString(),
-                                item.Children[new YamlScalarNode("authToken")].ToString()
+                                item.Children[new YamlScalarNode("authToken")].ToString(),
+                                (overrideArguments!=null) ? overrideArguments : item.Children[new YamlScalarNode("toolArguments")].ToString()
                                 ));
                         }
                         catch (Exception e)

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken: 
+    toolArguments: 
 ```
 
 Where:
@@ -213,6 +214,7 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser: aaaaaaa
     authToken: abcdefghijklmnopqrsthtnf
+    toolArguments: "-c All,GPOLocalGroup -d whatever.youlike.local"
 ```
 
 Where:
@@ -226,6 +228,7 @@ Where:
 - AuthUser: user name from GitHub
 - AuthToken: auth token from GitHub (documented at GitHub: [creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 ))
+- toolArguments: arguments to be embedded in the donut shellcode
 
 ## Add a tool from local git folder
 
@@ -239,6 +242,7 @@ tool:
     plugins: RandomGuid, RandomAssemblyInfo, BuildCsharp, ConfuserEx, Donut
     authUser:
     authToken: 
+    toolArguments:
 ```
 
 Where:
@@ -251,6 +255,7 @@ Where:
 - Plugins: plugins to user on this tool build process
 - AuthUser: user name from github (not used for local repositories)
 - AuthToken: auth token from github (not used for local repositories)
+- toolArguments: arguments to be embedded in the donut shellcode
 
 ## Requirements for the release version (Visual Studio 2019/2022 is not required)
 


### PR DESCRIPTION
Hi, hope you are well. Here I am with a modest contribution.
Donut allows to pass arguments to the generated shellcode, so I added the functionnality to pass arguments.
Here is an example use case :
- I want to always build Seatbelt using the `-group=all` argument > I can change the toolArguments value in the yaml description of Seatbelt, and the arguments will automatically be embedded in the shellcode at every build.
- One day, I decide I want to have a special Seatbelt shellcode, and override the "-group=all" argument with another one, I can simply do `OffensivePipeline.exe t seatbelt -a "-mynew=argument"`. This special build will override the yaml conf only this time.
- If I never supply `-a`, and never set toolArguments in yaml, then everything works like it worked before (i.e. no argument embedded)
- If I build using all, then `-a` is obviously not available anymore, and the toolsArguments of the yaml configs will be used.
![Screenshot from 2023-07-29 00-05-01](https://github.com/Aetsu/OffensivePipeline/assets/55366132/af9e7c41-9ef2-4db9-99bb-7a510bd223fe)
![Screenshot from 2023-07-29 00-05-14](https://github.com/Aetsu/OffensivePipeline/assets/55366132/5d163e3d-7c8b-49d5-afae-111301b0ed08)

